### PR TITLE
Feat/import routes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,41 +3,41 @@ info:
   description: "Botfront API"
   title: "Botfront API"
 consumes:
-- "application/json"
+  - "application/json"
 produces:
-- "application/json"
+  - "application/json"
 schemes:
-- "https"
+  - "https"
 
 paths:
   "/project/{project_id}/response/name/{name}/lang/{lang}":
     get:
       summary: Retrieve a bot response with its name
-      description:  >
+      description: >
         A bot response is a sequence of messages in the Botfront format. The JSON example below shows a simple text message but all the Botfront message types (Quick replies, images, Facebook templates, ...) can be returned in that array. 
-        Use the Bot Responses section of the Botfront app for a complete refence ( in `yaml`). 
+        Use the Bot Responses section of the Botfront app for a complete refence ( in `yaml`).
       operationId: getBotResponse
       parameters:
-      - name: project_id
-        in: path
-        description: Botfront project ID
-        required: true
-        type: string
-      - name: name
-        in: path
-        description: Bot response name
-        required: true
-        type: string
-      - name: lang
-        in: path
-        description: The bot response language
-        required: true
-        type: string
-      - name: metadata
-        in: query
-        description: if metadata is set to 1, the metadata field will be included in the response sequence
-        required: false
-        type: integer
+        - name: project_id
+          in: path
+          description: Botfront project ID
+          required: true
+          type: string
+        - name: name
+          in: path
+          description: Bot response name
+          required: true
+          type: string
+        - name: lang
+          in: path
+          description: The bot response language
+          required: true
+          type: string
+        - name: metadata
+          in: query
+          description: if metadata is set to 1, the metadata field will be included in the response sequence
+          required: false
+          type: integer
       responses:
         default:
           description: Unknown error
@@ -50,27 +50,27 @@ paths:
         200:
           description: Succesfull response
           schema:
-            $ref: '#/definitions/sequence'
-          
+            $ref: "#/definitions/sequence"
+
   "/project/{project_id}/responses":
     get:
       operationId: getAllResponses
       parameters:
-      - name: project_id
-        in: path
-        description: Botfront project ID
-        required: true
-        type: string
-      - name: timestamp
-        in: query
-        description: timestamp in ms of last update
-        required: false
-        type: number
-      - name: metadata
-        in: query
-        description: if metadata is set to 1, the metadata field will be included in the response sequence
-        required: false
-        type: integer
+        - name: project_id
+          in: path
+          description: Botfront project ID
+          required: true
+          type: string
+        - name: timestamp
+          in: query
+          description: timestamp in ms of last update
+          required: false
+          type: number
+        - name: metadata
+          in: query
+          description: if metadata is set to 1, the metadata field will be included in the response sequence
+          required: false
+          type: integer
       produces:
         - application/json
       summary: Retrieve all bot responses. If you pass the `timestamp` query param it will compare it with the last update time of the responses. If they have not been modified, a 304 response is returned. This allows to periodically check for updates
@@ -82,7 +82,7 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/bot_responses'
+            $ref: "#/definitions/bot_responses"
         304:
           description: Not modified
 
@@ -90,25 +90,25 @@ paths:
     post:
       operationId: getResponse
       parameters:
-      - name: project_id
-        in: path
-        description: Botfront project ID
-        required: true
-        type: string
-      - in: body
-        name: body
-        description: NLU information the response should match
-        schema:
-          $ref: '#/definitions/matching_criteria'
-      - name: metadata
-        in: query
-        description: if metadata is set to 1, the metadata field will be included in the response sequence
-        required: false
-        type: integer
+        - name: project_id
+          in: path
+          description: Botfront project ID
+          required: true
+          type: string
+        - in: body
+          name: body
+          description: NLU information the response should match
+          schema:
+            $ref: "#/definitions/matching_criteria"
+        - name: metadata
+          in: query
+          description: if metadata is set to 1, the metadata field will be included in the response sequence
+          required: false
+          type: integer
       produces:
         - application/json
       summary: Retrieve a bot response matching NLU criteria
-      description:  >
+      description: >
         A bot response is a sequence of messages in the Botfront format. The JSON example below shows a simple text message but all the Botfront message types (Quick replies, images, Facebook templates, ...) can be returned in that array. 
         Use the Bot Responses section of the Botfront app for a complete refence ( in `yaml`). 
 
@@ -125,9 +125,8 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/bot_response'
-            
- 
+            $ref: "#/definitions/bot_response"
+
   # "/project/{project_id}/tracker/{sender_id}/tag/{tag}":
   #   get:
   #     summary: Legacy tracker update endpoint.
@@ -159,7 +158,7 @@ paths:
   #         description: Unauthorized
   #       200:
   #         description: Ok
-            
+
   # "/project/{project_id}/conversations/{sender_id}/{event_count}":
   #   get:
   #     summary: Gets a tracker with the `event_count` latest events.
@@ -192,7 +191,6 @@ paths:
   #       200:
   #         description: Ok
 
-
   # "/project/{project_id}/conversations/{sender_id}/insert":
   #   post:
   #     summary: Creates a new tracker.
@@ -220,7 +218,7 @@ paths:
   #         description: Unauthorized
   #       200:
   #         description: Ok
-          
+
   # "/project/{project_id}/conversations/{sender_id}/update":
   #   post:
   #     summary: Updates conversation tracker.
@@ -295,7 +293,6 @@ paths:
   #       200:
   #         description: Ok
 
-
   # "/project/{project_id}/endpoints":
   #   get:
   #     summary: Returns CORE endpoints.
@@ -325,11 +322,11 @@ paths:
       # description: Parse an utterance and returns NLU structured output.
       operationId: getModelsPublished
       parameters:
-      - name: project_id
-        in: path
-        description: Botfront project ID
-        required: true
-        type: string
+        - name: project_id
+          in: path
+          description: Botfront project ID
+          required: true
+          type: string
       responses:
         default:
           description: Unknown error
@@ -341,21 +338,21 @@ paths:
           description: Unauthorized
         200:
           description: Ok
-  
+
   "/conversations/{projectId}/environment/{env}/latest-imported-event":
     get:
       operationId: getLastestImportedEvent,
       parameters:
-      - name: project_id
-        in: path
-        description: Botfront project ID
-        required: true
-        type: string
-      - name: env
-        in: path
-        description: environement to get latest imported event from, should be one of production, staging, developement
-        required: true
-        type: string
+        - name: project_id
+          in: path
+          description: Botfront project ID
+          required: true
+          type: string
+        - name: env
+          in: path
+          description: environement to get latest imported event from, should be one of production, staging, development
+          required: true
+          type: string
       produces:
         - application/json
       responses:
@@ -363,13 +360,13 @@ paths:
           description: Unknown error
         400:
           description: Bad request
-          schema: {error: <errorMessage>}
+          schema: { error: <errorMessage> }
         401:
           description: Unauthorized
         200:
           description: OK
           schema:
-            $ref: '#/definitions/timestamp'
+            $ref: "#/definitions/timestamp"
         500:
           description: Internal Server Error
 
@@ -377,28 +374,28 @@ paths:
     post:
       operationId: importNewConversation,
       parameters:
-      - name: project_id
-        in: path
-        description: Botfront project ID
-        required: true
-        type: string
-      - name: env
-        in: path
-        description: environement to import to, should be one of production, staging, developement
-        required: true
-        type: string
-      - name: conversations
-        in: body
-        description: conversations to import
-        required: true
-        type: array
-        schema:
-            $ref: '#/definitions/conversations'
-      - name: processNlu
-        in: body
-        description: copy parse_data to activity if true
-        required: true
-        type: boolean
+        - name: project_id
+          in: path
+          description: Botfront project ID
+          required: true
+          type: string
+        - name: env
+          in: path
+          description: environement to import to, should be one of production, staging, development
+          required: true
+          type: string
+        - name: conversations
+          in: body
+          description: conversations to import
+          required: true
+          type: array
+          schema:
+            $ref: "#/definitions/conversations"
+        - name: processNlu
+          in: body
+          description: copy parse_data to activity if true
+          required: true
+          type: boolean
       produces:
         - application/json
       responses:
@@ -411,12 +408,11 @@ paths:
           description: Unauthorized
         206:
           description: Partial Content
-          summary: some parts of the data were not formated correctly and not added, they are returned in the response body 
+          summary: some parts of the data were not formated correctly and not added, they are returned in the response body
         200:
           description: OK
         500:
           description: Internal Server Error
-         
 
   "/api-docs":
     get:
@@ -434,11 +430,11 @@ paths:
     get:
       summary: API documentation
       parameters:
-      - name: file
-        in: path
-        description: Botfront project ID
-        required: true
-        type: string
+        - name: file
+          in: path
+          description: Botfront project ID
+          required: true
+          type: string
       security: []
       # description: Parse an utterance and returns NLU structured output.
       operationId: apiDocsDeps
@@ -447,23 +443,22 @@ paths:
           description: Unknown error
         200:
           description: Ok
-          
-          
+
 definitions:
   matching_criteria:
     type: object
     properties:
       nlu:
         type: object
-        properties: 
-          intent: 
+        properties:
+          intent:
             type: string
             example: greet
           entities:
             type: array
             items:
               type: object
-              properties: 
+              properties:
                 entity:
                   type: string
                   example: city
@@ -473,22 +468,22 @@ definitions:
   bot_response:
     type: object
     properties:
-      key: 
+      key:
         type: string
         example: utter_something
-      follow_up: 
+      follow_up:
         type: string
         example: utter_something
       values:
         type: array
         items:
-          $ref: '#/definitions/sequence'
+          $ref: "#/definitions/sequence"
   sequence:
     description: test
     type: array
     items:
-      $ref: '#/definitions/quick_replies'
-  
+      $ref: "#/definitions/quick_replies"
+
   timestamp:
     properties:
       timestamp:
@@ -501,13 +496,12 @@ definitions:
       text:
         type: string
         example: Something
-  
+
   conversations:
-     definition: array of conversation element from the db
-     type: array
-     items:
+    definition: array of conversation element from the db
+    type: array
+    items:
       type: object
-    
 
   bot_responses:
     type: object
@@ -529,14 +523,14 @@ definitions:
                 type: object
                 properties:
                   sequence:
-                    $ref: '#/definitions/sequence'
+                    $ref: "#/definitions/sequence"
                   lang:
                     type: string
-                    example: 'fr'
+                    example: "fr"
             match:
               type: object
-              $ref: '#/definitions/matching_criteria'
-  
+              $ref: "#/definitions/matching_criteria"
+
   quick_replies:
     type: object
     properties:
@@ -554,11 +548,9 @@ definitions:
             payload:
               type: string
               example: "/basics.yes"
-              
-
 
 security:
-- api_key: []
+  - api_key: []
 
 securityDefinitions:
   # This section configures basic authentication with an API key.
@@ -566,5 +558,3 @@ securityDefinitions:
     type: "apiKey"
     name: "key"
     in: "query"
- 
-  

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -126,7 +126,8 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/bot_response'
-
+            
+ 
   # "/project/{project_id}/tracker/{sender_id}/tag/{tag}":
   #   get:
   #     summary: Legacy tracker update endpoint.
@@ -340,6 +341,82 @@ paths:
           description: Unauthorized
         200:
           description: Ok
+  
+  "/conversations/{projectId}/environment/{env}/latest-imported-event":
+    get:
+      operationId: getLastestImportedEvent,
+      parameters:
+      - name: project_id
+        in: path
+        description: Botfront project ID
+        required: true
+        type: string
+      - name: env
+        in: path
+        description: environement to get latest imported event from, should be one of production, staging, developement
+        required: true
+        type: string
+      produces:
+        - application/json
+      responses:
+        default:
+          description: Unknown error
+        400:
+          description: Bad request:
+          schema: {error: <errorMessage>}
+        401:
+          description: Unauthorized
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/timestamp'
+        500:
+          description: Internal Server Error
+
+  "/conversations/{projectId}/environment/{env}":
+    post:
+      operationId: importNewConversation,
+      parameters:
+      - name: project_id
+        in: path
+        description: Botfront project ID
+        required: true
+        type: string
+      - name: env
+        in: path
+        description: environement to import to, should be one of production, staging, developement
+        required: true
+        type: string
+      - name: conversations
+        in: body
+        description: conversations to import
+        required: true
+        type: array
+        schema:
+            $ref: '#/definitions/conversations'
+      - name: processNlu
+        in: body
+        description: copy parse_data to activity if true
+        required: true
+        type: boolean
+      produces:
+        - application/json
+      responses:
+        default:
+          description: Unknown error
+        400:
+          description: Bad request:
+            summary: the format of the parameters was not correct
+        401:
+          description: Unauthorized;
+        206:
+          description: Partial Content:
+          summary: some parts of the data were not formated correctly and not added, they are returned in the response body 
+        200:
+          description: OK
+        500:
+          description: Internal Server Error
+         
 
   "/api-docs":
     get:
@@ -370,6 +447,7 @@ paths:
           description: Unknown error
         200:
           description: Ok
+          
           
 definitions:
   matching_criteria:
@@ -411,12 +489,25 @@ definitions:
     items:
       $ref: '#/definitions/quick_replies'
   
+  timestamp:
+    properties:
+      timestamp:
+        type: integer
+        example: 1550677361363
+
   message:
     type: object
     properties:
       text:
         type: string
         example: Something
+  
+  conversations:
+     definition: array of conversation element from the db
+     type: array
+     items:
+      type: object
+    
 
   bot_responses:
     type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -362,7 +362,7 @@ paths:
         default:
           description: Unknown error
         400:
-          description: Bad request:
+          description: Bad request
           schema: {error: <errorMessage>}
         401:
           description: Unauthorized
@@ -405,12 +405,12 @@ paths:
         default:
           description: Unknown error
         400:
-          description: Bad request:
-            summary: the format of the parameters was not correct
+          description: Bad request
+          summary: the format of the parameters was not correct
         401:
-          description: Unauthorized;
+          description: Unauthorized
         206:
-          description: Partial Content:
+          description: Partial Content
           summary: some parts of the data were not formated correctly and not added, they are returned in the response body 
         200:
           description: OK

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,7 +13,7 @@ const { getSenderEventCount, insertConversation, updateConversation } = require(
 const { getProjectCredentials } = require('../server/credentials/credentials.controller');
 const { getProjectEndpoints } = require('../server/endpoints/endpoints.controller');
 const { getPublishedModels } = require('../server/nlu_models/nlu_models.controller');
-const { importConversation, lastestImport } = require('../server/imports/imports.controller');
+const { importConversation, importConversationValidator, lastestImport, lastestImportValidator } = require('../server/imports/imports.controller');
 const {
     exportProject,
     exportProjectValidator,
@@ -46,11 +46,8 @@ router.put('/project/:project_id/import', importProjectValidator, importProject)
 router.get('/project/:project_id/models/published', getPublishedModels);
 router.get('/health-check', (req, res) => res.status(200).json());
 
-router.post("/conversations/:project_id/environment/:env", importConversation);
-router.get(
-  "/conversations/:project_id/environment/:env/latest-imported-event",
-  lastestImport
-);
+router.post('/conversations/:project_id/environment/:env', importConversationValidator, importConversation);
+router.get('/conversations/:project_id/environment/:env/latest-imported-event', lastestImportValidator, lastestImport);
 
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,6 +13,7 @@ const { getSenderEventCount, insertConversation, updateConversation } = require(
 const { getProjectCredentials } = require('../server/credentials/credentials.controller');
 const { getProjectEndpoints } = require('../server/endpoints/endpoints.controller');
 const { getPublishedModels } = require('../server/nlu_models/nlu_models.controller');
+const { importConversation, lastestImport } = require('../server/imports/imports.controller');
 const {
     exportProject,
     exportProjectValidator,
@@ -44,5 +45,9 @@ router.put('/project/:project_id/import', importProjectValidator, importProject)
 
 router.get('/project/:project_id/models/published', getPublishedModels);
 router.get('/health-check', (req, res) => res.status(200).json());
+
+router.post('/conversations/environment/:env', importConversation);
+router.get('/conversations/environment/:env/latest-imported-event', lastestImport);
+
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -46,8 +46,11 @@ router.put('/project/:project_id/import', importProjectValidator, importProject)
 router.get('/project/:project_id/models/published', getPublishedModels);
 router.get('/health-check', (req, res) => res.status(200).json());
 
-router.post('/conversations/environment/:env', importConversation);
-router.get('/conversations/environment/:env/latest-imported-event', lastestImport);
+router.post("/conversations/:project_id/environment/:env", importConversation);
+router.get(
+  "/conversations/:project_id/environment/:env/latest-imported-event",
+  lastestImport
+);
 
 
 module.exports = router;

--- a/server/imports/imports.controller.js
+++ b/server/imports/imports.controller.js
@@ -105,10 +105,9 @@ exports.importConversation = async function(req, res) {
     if (!project) throw { code: 401, error: "unauthorized" };
     const { env } = req.params;
     // checks for parameters correctness
-    if (!["production", "staging", "developement"].includes(env)) {
+    if (!["production", "staging", "development"].includes(env)) {
       return res.status(400).json({
-        error:
-          "environement should be one of: production, staging, developement"
+        error: "environement should be one of: production, staging, development"
       });
     }
     if (conversations === undefined || processNlu === undefined) {
@@ -212,10 +211,9 @@ exports.lastestImport = async function(req, res) {
     const project = await getVerifiedProject(projectId, req);
     if (!project) throw { code: 401, error: "unauthorized" };
     // checks for parameters correctness
-    if (!["production", "staging", "developement"].includes(env)) {
+    if (!["production", "staging", "development"].includes(env)) {
       return res.status(400).json({
-        error:
-          "environement should be one of: production, staging, developement"
+        error: "environement should be one of: production, staging, development"
       });
     }
     const oldest = await getOldestTimeStamp(env);

--- a/server/imports/imports.controller.js
+++ b/server/imports/imports.controller.js
@@ -1,0 +1,147 @@
+const {
+  Conversations,
+  Projects,
+  NLUModels,
+  Activity
+} = require('../../models/models');
+
+retreiveProjectsAndModelsIds = async function() {
+  const projects = await Projects.find({})
+    .select('nlu_models _id')
+    .lean()
+    .exec();
+
+  projectAndModels = projects.map(async project => {
+    nluModels = await project.nlu_models.map(async projectNluModel => {
+      nluModel = NLUModels.findOne({ _id: projectNluModel })
+        .select('_id language')
+        .lean()
+        .exec();
+      return nluModel;
+    });
+    nluModels = await Promise.all(nluModels);
+    return { projectId: project._id, nluModels: nluModels };
+  });
+  return await Promise.all(projectAndModels);
+};
+
+inferModelId = function(projectId, language, projectsAndModels) {
+  const project = projectsAndModels.find(
+    projectAndModels => projectAndModels.projectId === projectId
+  );
+  const modelId = project.nluModels.find(
+    nluModel => nluModel.language === language
+  );
+  return modelId._id;
+};
+
+addParseDataToActivity = async function(conversation, oldestImportTimestamp) {
+  const projectsAndModels = await retreiveProjectsAndModelsIds();
+  let parseDataToAdd = [];
+  const projectId = conversation.projectId;
+  conversation.tracker.events.forEach(event => {
+    if (
+      event.parse_data !== undefined &&
+      event.parse_data.language !== undefined &&
+      event.timestamp > oldestImportTimestamp
+    ) {
+      const { intent, entities, text } = event.parse_data;
+      const modelId = inferModelId(
+        projectId,
+        event.parse_data.language,
+        projectsAndModels
+      );
+      parseDataToAdd.push({
+        modelId,
+        text,
+        intent: intent.name,
+        entities,
+        confidence: intent.confidence,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      });
+    }
+  });
+  Activity.insertMany(parseDataToAdd);
+};
+
+exports.importConversation = async function(req, res) {
+  const { conversations, processNlu } = req.body;
+  const { env } = req.params;
+  // checks for parameters correctness
+  if (!['production', 'stagging', 'developement'].includes(env)) {
+    return res.status(400).json({
+      error: 'environement should be one of: production, stagging, developement'
+    });
+  }
+  if (!Array.isArray(conversations)) {
+    return res.status(400).json({ error: 'conversations should be an array' });
+  }
+
+  if (typeof processNlu !== 'boolean') {
+    return res.status(400).json({ error: 'processNlu should be an boolean' });
+  }
+
+  let projectIds = await Projects.find({})
+    .select('_id')
+    .exec();
+  projectIds = projectIds.map(project => project._id);
+
+  let notAdded = [];
+  oldestImport = await getOldestTimeStamp(env);
+
+  conversations.forEach(conversation => {
+    if (
+      conversation._id !== undefined &&
+      projectIds.includes(conversation.projectId)
+    ) {
+      Conversations.updateOne(
+        { _id: conversation._id },
+        {
+          ...conversation,
+          env,
+          updatedAt: new Date(),
+          createdAt: new Date(conversation.createdAt)
+        },
+        { upsert: true },
+        function(err) {
+          if (err) return res.status(400).json(err);
+        }
+      );
+      if (processNlu) addParseDataToActivity(conversation, oldestImport);
+    } else {
+      notAdded.push(conversation);
+    }
+  });
+  if (notAdded.length > 0)
+    return res.status(206).json({
+      message:
+        'some conversation were not added, either the _id is missing or projectId does not exist',
+      notAdded
+    });
+  return res
+    .status(200)
+    .json({ message: 'successfuly imported all conversations' });
+};
+
+getOldestTimeStamp = async function(env) {
+  const lastestAddition = await Conversations.findOne({ env: env })
+    .select('updatedAt')
+    .sort('-updatedAt')
+    .lean()
+    .exec();
+  if (lastestAddition) return Math.floor(lastestAddition.updatedAt / 1000);
+  return 0;
+};
+
+exports.lastestImport = async function(req, res) {
+  const { env } = req.params;
+  // checks for parameters correctness
+  if (!['production', 'stagging', 'developement'].includes(env)) {
+    return res.status(400).json({
+      error: 'environement should be one of: production, stagging, developement'
+    });
+  }
+  const oldest = await getOldestTimeStamp(env);
+  return res.status(200).json({ timestamp: oldest });
+};

--- a/server/imports/imports.controller.js
+++ b/server/imports/imports.controller.js
@@ -10,18 +10,19 @@ retreiveProjectsAndModelsIds = async function() {
     .select('nlu_models _id')
     .lean()
     .exec();
-
-  projectAndModels = projects.map(async project => {
-    nluModels = await project.nlu_models.map(async projectNluModel => {
-      nluModel = NLUModels.findOne({ _id: projectNluModel })
-        .select('_id language')
-        .lean()
-        .exec();
-      return nluModel;
+  projectAndModels = projects
+    .filter(project => project.nlu_models !== undefined)
+    .map(async project => {
+      nluModels = await project.nlu_models.map(async projectNluModel => {
+        nluModel = NLUModels.findOne({ _id: projectNluModel })
+          .select('_id language')
+          .lean()
+          .exec();
+        return nluModel;
+      });
+      nluModels = await Promise.all(nluModels);
+      return { projectId: project._id, nluModels: nluModels };
     });
-    nluModels = await Promise.all(nluModels);
-    return { projectId: project._id, nluModels: nluModels };
-  });
   return await Promise.all(projectAndModels);
 };
 
@@ -32,7 +33,8 @@ inferModelId = function(projectId, language, projectsAndModels) {
   const modelId = project.nluModels.find(
     nluModel => nluModel.language === language
   );
-  return modelId._id;
+  if (modelId) return modelId._id;
+  return undefined;
 };
 
 addParseDataToActivity = async function(conversation, oldestImportTimestamp) {
@@ -44,6 +46,7 @@ addParseDataToActivity = async function(conversation, oldestImportTimestamp) {
     if (
       event.parse_data !== undefined &&
       event.parse_data.language !== undefined &&
+      event.parse_data.text !== '' &&
       event.timestamp > oldestImportTimestamp
     ) {
       const { intent, entities, text } = event.parse_data;
@@ -54,8 +57,8 @@ addParseDataToActivity = async function(conversation, oldestImportTimestamp) {
       );
       if (modelId) {
         parseDataToAdd.push({
-          modelId,
-          text,
+          modelId: modelId,
+          text: text,
           intent: intent.name,
           entities,
           confidence: intent.confidence,
@@ -72,7 +75,7 @@ addParseDataToActivity = async function(conversation, oldestImportTimestamp) {
 
 createConversationsToAdd = function(conversations, env, projectsIds) {
   const toAdd = [];
-  const invalids = [];
+  const notValids = [];
   conversations.forEach(conversation => {
     if (
       conversation._id !== undefined &&
@@ -85,7 +88,7 @@ createConversationsToAdd = function(conversations, env, projectsIds) {
         createdAt: new Date(conversation.createdAt)
       });
     } else {
-      invalids.push(conversation);
+      notValids.push(conversation);
     }
   });
 
@@ -99,6 +102,11 @@ exports.importConversation = async function(req, res) {
   if (!['production', 'staging', 'developement'].includes(env)) {
     return res.status(400).json({
       error: 'environement should be one of: production, staging, developement'
+    });
+  }
+  if (conversations === undefined || processNlu === undefined) {
+    return res.status(400).json({
+      error: 'the body is missing conversations or processNlu, or both'
     });
   }
   if (!Array.isArray(conversations)) {
@@ -123,41 +131,53 @@ exports.importConversation = async function(req, res) {
 
   //delacred out of the forEach Block so it can be accessed later
   const invalidParseDatas = [];
-  // add each prepared conversatin to the db
-  toAdd.forEach(conversation => {
-    Conversations.updateOne(
-      { _id: conversation._id },
-      conversation,
-      { upsert: true },
-      function(err) {
-        if (err) return res.status(400).json(err);
-      }
-    );
-    if (processNlu) {
-      const { parseDataToAdd, invalidParseData } = addParseDataToActivity(
+  // add each prepared conversatin to the db, a promise all is used to ensure that all data is added before checking for errors
+  errors = [];
+  await Promise.all(
+    toAdd.map(async conversation => {
+      Conversations.updateOne(
+        { _id: conversation._id },
         conversation,
-        oldestImport
+        { upsert: true },
+        function(err) {
+          if (err) errors.push(err);
+        }
       );
-      Activity.insertMany(parseDataToAdd);
-      if (invalidParseData.length > 0) invalidParseDatas.push(invalidParseData);
-    }
-  });
+      if (processNlu) {
+        const {
+          parseDataToAdd,
+          invalidParseData
+        } = await addParseDataToActivity(conversation, oldestImport);
+        if (parseDataToAdd && parseDataToAdd.length > 0) {
+          await Activity.insertMany(parseDataToAdd, function(err) {
+            if (err) errors.push(err);
+          });
+        }
+        if (invalidParseData && invalidParseData.length > 0)
+          invalidParseDatas.push(invalidParseData);
+      }
+    })
+  );
+
+  if (errors.length > 0) {
+    return res.status(500).json(errors);
+  }
 
   //create a report of the errors, if any
-  const error = {};
-  if (notValids.length > 0) {
-    error.messageConversation =
+  const formatsError = {};
+  if (notValids && notValids.length > 0) {
+    formatsError.messageConversation =
       'some conversation were not added, either the _id is missing or projectId does not exist';
-    error.notValids = notValids;
+    formatsError.notValids = notValids;
   }
   if (invalidParseDatas.length > 0) {
-    error.messageParseData =
+    formatsError.messageParseData =
       'Some parseData have not been added to activity, the corresponding models could not be found ';
-    error.invalidParseDatas = invalidParseDatas;
+    formatsError.invalidParseDatas = invalidParseDatas;
   }
   //object not empty
-  if (Object.keys(error).length !== 0) {
-    return res.status(206).json(error);
+  if (Object.keys(formatsError).length !== 0) {
+    return res.status(206).json(formatsError);
   }
 
   return res

--- a/server/imports/imports.test.js
+++ b/server/imports/imports.test.js
@@ -165,11 +165,13 @@ describe('## import format checking', () => {
             .exec()
             .then(newData => {
               expect(newData).to.have.length(1);
+              expect(newData[0].projectId).to.equal('pro1');
               Conversations.find({ _id: 'update' })
                 .lean()
                 .exec()
                 .then(updateData => {
                   expect(updateData).to.have.length(1);
+                  expect(updateData[0].projectId).to.equal('pro1');
                   expect(updateData[0].updatedAt).to.not.equal(
                     new Date(1550000000)
                   );
@@ -186,7 +188,7 @@ describe('## import format checking', () => {
         });
     });
 
-    it('should not import a conversation with a non existing project id', done => {
+    it('should not import a conversation with a non undefined id', done => {
       request(app)
         .post('/conversations/pro1/environment/production')
         .send({
@@ -197,7 +199,7 @@ describe('## import format checking', () => {
         .then(async res => {
           expect(res.body).to.deep.equal({
             messageConversation:
-              'some conversation were not added, either the _id is missing or projectId does not exist',
+              'some conversation were not added, the field _id is missing',
             notValids: [conversationsToImport[2]]
           });
           Conversations.find({ _id: 'projectnotexist' })
@@ -210,7 +212,7 @@ describe('## import format checking', () => {
         })
         .catch(done);
     });
-    it('should not import a wrong parse data with a non existing project id', done => {
+    it('should not import a parse data with unsupported language (no corresponding model)', done => {
       request(app)
         .post('/conversations/pro1/environment/production')
         .send({
@@ -221,9 +223,9 @@ describe('## import format checking', () => {
         .then(async res => {
           expect(res.body).to.deep.equal({
             messageParseData:
-              'Some parseData have not been added to activity, the corresponding models could not be found ',
+              'Some parseData have not been added to activity, the corresponding models could not be found',
             invalidParseDatas: [
-              [conversationsToImport[3].tracker.events[6].parse_data]
+              [conversationsToImport[3].tracker.events[0].parse_data]
             ]
           });
           Conversations.find({ _id: 'projectnotexist' })

--- a/server/imports/imports.test.js
+++ b/server/imports/imports.test.js
@@ -42,10 +42,10 @@ before(function(done) {
 });
 
 describe('## last import', () => {
-  describe('# GET /conversations/environment/{env}/latest-imported-event', () => {
+  describe('# GET /conversations/{projectId}/environment/{env}/latest-imported-event', () => {
     it('Should retrieve last import in production', done => {
       request(app)
-        .get('/conversations/environment/production/latest-imported-event')
+        .get('/conversations/pro1/environment/production/latest-imported-event')
         .expect(httpStatus.OK)
         .then(res => {
           expect(res.body).to.deep.equal({
@@ -58,7 +58,7 @@ describe('## last import', () => {
 
     it('Should give 0 as no import yet in staging', done => {
       request(app)
-        .get('/conversations/environment/staging/latest-imported-event')
+        .get('/conversations/pro1/environment/staging/latest-imported-event')
         .expect(httpStatus.OK)
         .then(res => {
           expect(res.body).to.deep.equal({
@@ -71,7 +71,7 @@ describe('## last import', () => {
 
     it('Should retrieve last import in developement', done => {
       request(app)
-        .get('/conversations/environment/developement/latest-imported-event')
+        .get('/conversations/pro1/environment/developement/latest-imported-event')
         .expect(httpStatus.OK)
         .then(res => {
           expect(res.body).to.deep.equal({
@@ -84,7 +84,7 @@ describe('## last import', () => {
 
     it('Should return 400 when envirnonement does not exist', done => {
       request(app)
-        .get('/conversations/environment/prodduction/latest-imported-event')
+        .get('/conversations/pro1/environment/prodduction/latest-imported-event')
         .expect(httpStatus.BAD_REQUEST)
         .then(res => {
           expect(res.body).to.deep.equal({
@@ -99,10 +99,10 @@ describe('## last import', () => {
 });
 
 describe('## import format checking', () => {
-  describe('# POST /conversations/environment/{env}', () => {
+  describe('# POST /conversations/{projectId}/environment/{env}', () => {
     it('should fail with invalid body', done => {
       request(app)
-        .post('/conversations/environment/production')
+        .post('/conversations/pro1/environment/production')
         .send({
           dummy: [{ name: 'test', confidence: 0.99 }],
           text: 'blabla'
@@ -118,7 +118,7 @@ describe('## import format checking', () => {
     });
     it('should fail with invalid conversations type', done => {
       request(app)
-        .post('/conversations/environment/production')
+        .post('/conversations/pro1/environment/production')
         .send({
           conversations: 'bad',
           processNlu: false
@@ -134,7 +134,7 @@ describe('## import format checking', () => {
     });
     it('should fail with invalid processNlu type', done => {
       request(app)
-        .post('/conversations/environment/production')
+        .post('/conversations/pro1/environment/production')
         .send({
           conversations: [],
           processNlu: 'false'
@@ -150,7 +150,7 @@ describe('## import format checking', () => {
     });
     it('should import a new conversation and update and oldOne', done => {
       request(app)
-        .post('/conversations/environment/production')
+        .post('/conversations/pro1/environment/production')
         .send({
           conversations: conversationsToImport.slice(0, 2),
           processNlu: true
@@ -188,7 +188,7 @@ describe('## import format checking', () => {
 
     it('should not import a conversation with a non existing project id', done => {
       request(app)
-        .post('/conversations/environment/production')
+        .post('/conversations/pro1/environment/production')
         .send({
           conversations: conversationsToImport.slice(2, 3),
           processNlu: true
@@ -212,7 +212,7 @@ describe('## import format checking', () => {
     });
     it('should not import a wrong parse data with a non existing project id', done => {
       request(app)
-        .post('/conversations/environment/production')
+        .post('/conversations/pro1/environment/production')
         .send({
           conversations: conversationsToImport.slice(3),
           processNlu: true

--- a/server/imports/imports.test.js
+++ b/server/imports/imports.test.js
@@ -4,7 +4,17 @@ const chai = require('chai');
 const expect = chai.expect;
 const app = require('../../app');
 chai.config.includeStack = true;
-const { Projects, NLUModels, Conversations } = require('../../models/models');
+const fs = require('fs');
+const {
+  Projects,
+  NLUModels,
+  Conversations,
+  Activity
+} = require('../../models/models');
+
+const conversationsToImport = JSON.parse(
+  fs.readFileSync(__dirname + '/test_data/conversationsToImport.json', 'utf8')
+);
 
 function dateParser(key, value) {
   if (key === 'updatedAt' || key === 'createdAt') {
@@ -13,7 +23,6 @@ function dateParser(key, value) {
   return value;
 }
 before(function(done) {
-  const fs = require('fs');
   const projectsFile = __dirname + '/test_data/projects.json';
   const modelsFile = __dirname + '/test_data/nluModels.json';
   const conversationFile = __dirname + '/test_data/conversations.json';
@@ -23,6 +32,7 @@ before(function(done) {
     fs.readFileSync(conversationFile, 'utf8'),
     dateParser
   );
+
   Projects.insertMany(projects)
     .then(() => NLUModels.insertMany(models))
     .then(() => Conversations.insertMany(conversation))
@@ -82,6 +92,147 @@ describe('## last import', () => {
               'environement should be one of: production, staging, developement'
           });
           done();
+        })
+        .catch(done);
+    });
+  });
+});
+
+describe('## import format checking', () => {
+  describe('# POST /conversations/environment/{env}', () => {
+    it('should fail with invalid body', done => {
+      request(app)
+        .post('/conversations/environment/production')
+        .send({
+          dummy: [{ name: 'test', confidence: 0.99 }],
+          text: 'blabla'
+        })
+        .expect(httpStatus.BAD_REQUEST)
+        .then(res => {
+          expect(res.body).to.deep.equal({
+            error: 'the body is missing conversations or processNlu, or both'
+          });
+          done();
+        })
+        .catch(done);
+    });
+    it('should fail with invalid conversations type', done => {
+      request(app)
+        .post('/conversations/environment/production')
+        .send({
+          conversations: 'bad',
+          processNlu: false
+        })
+        .expect(httpStatus.BAD_REQUEST)
+        .then(res => {
+          expect(res.body).to.deep.equal({
+            error: 'conversations should be an array'
+          });
+          done();
+        })
+        .catch(done);
+    });
+    it('should fail with invalid processNlu type', done => {
+      request(app)
+        .post('/conversations/environment/production')
+        .send({
+          conversations: [],
+          processNlu: 'false'
+        })
+        .expect(httpStatus.BAD_REQUEST)
+        .then(res => {
+          expect(res.body).to.deep.equal({
+            error: 'processNlu should be an boolean'
+          });
+          done();
+        })
+        .catch(done);
+    });
+    it('should import a new conversation and update and oldOne', done => {
+      request(app)
+        .post('/conversations/environment/production')
+        .send({
+          conversations: conversationsToImport.slice(0, 2),
+          processNlu: true
+        })
+        .expect(httpStatus.OK)
+        .then(async res => {
+          expect(res.body).to.deep.equal({
+            message: 'successfuly imported all conversations'
+          });
+          Conversations.find({ _id: 'new' })
+            .lean()
+            .exec()
+            .then(newData => {
+              expect(newData).to.have.length(1);
+              Conversations.find({ _id: 'update' })
+                .lean()
+                .exec()
+                .then(updateData => {
+                  expect(updateData).to.have.length(1);
+                  expect(updateData[0].updatedAt).to.not.equal(
+                    new Date(1550000000)
+                  );
+                  Activity.find({ text: 'newevent' })
+                    .lean()
+                    .exec()
+                    .then(activityData => {
+                      expect(activityData).to.have.length(1);
+                      done();
+                    });
+                });
+            })
+            .catch(done);
+        });
+    });
+
+    it('should not import a conversation with a non existing project id', done => {
+      request(app)
+        .post('/conversations/environment/production')
+        .send({
+          conversations: conversationsToImport.slice(2, 3),
+          processNlu: true
+        })
+        .expect(httpStatus.PARTIAL_CONTENT)
+        .then(async res => {
+          expect(res.body).to.deep.equal({
+            messageConversation:
+              'some conversation were not added, either the _id is missing or projectId does not exist',
+            notValids: [conversationsToImport[2]]
+          });
+          Conversations.find({ _id: 'projectnotexist' })
+            .lean()
+            .exec()
+            .then(newData => {
+              expect(newData).to.have.length(0);
+              done();
+            });
+        })
+        .catch(done);
+    });
+    it('should not import a wrong parse data with a non existing project id', done => {
+      request(app)
+        .post('/conversations/environment/production')
+        .send({
+          conversations: conversationsToImport.slice(3),
+          processNlu: true
+        })
+        .expect(httpStatus.PARTIAL_CONTENT)
+        .then(async res => {
+          expect(res.body).to.deep.equal({
+            messageParseData:
+              'Some parseData have not been added to activity, the corresponding models could not be found ',
+            invalidParseDatas: [
+              [conversationsToImport[3].tracker.events[6].parse_data]
+            ]
+          });
+          Conversations.find({ _id: 'projectnotexist' })
+            .lean()
+            .exec()
+            .then(newData => {
+              expect(newData).to.have.length(0);
+              done();
+            });
         })
         .catch(done);
     });

--- a/server/imports/imports.test.js
+++ b/server/imports/imports.test.js
@@ -89,11 +89,17 @@ describe("## last import", () => {
         .get(
           "/conversations/pro1/environment/prodduction/latest-imported-event"
         )
-        .expect(httpStatus.BAD_REQUEST)
+        .expect(httpStatus.UNPROCESSABLE_ENTITY)
         .then(res => {
           expect(res.body).to.deep.equal({
-            error:
-              "environement should be one of: production, staging, development"
+            "errors": [
+                  {
+                    location: 'params',
+                    msg: 'environement should be one of: production, staging, development',
+                    param: 'env',
+                    value: 'prodduction',
+                  }
+                ]
           });
           done();
         })
@@ -111,10 +117,21 @@ describe("## import format checking", () => {
           dummy: [{ name: "test", confidence: 0.99 }],
           text: "blabla"
         })
-        .expect(httpStatus.BAD_REQUEST)
+        .expect(httpStatus.UNPROCESSABLE_ENTITY)
         .then(res => {
           expect(res.body).to.deep.equal({
-            error: "the body is missing conversations or processNlu, or both"
+            errors: [
+                  {
+                    location: 'body',
+                    msg: 'conversations should be an array',
+                    param: 'conversations'
+                  },
+                  {
+                    location: 'body',
+                    msg: 'processNlu should be an boolean',
+                    param: 'processNlu',
+                  }
+                ]
           });
           done();
         })
@@ -127,10 +144,17 @@ describe("## import format checking", () => {
           conversations: "bad",
           processNlu: false
         })
-        .expect(httpStatus.BAD_REQUEST)
+        .expect(httpStatus.UNPROCESSABLE_ENTITY)
         .then(res => {
           expect(res.body).to.deep.equal({
-            error: "conversations should be an array"
+            errors: [
+                  {
+                    location: 'body',
+                    msg: 'conversations should be an array',
+                    param: 'conversations',
+                    value: 'bad',
+                  }
+                ]
           });
           done();
         })
@@ -141,12 +165,19 @@ describe("## import format checking", () => {
         .post("/conversations/pro1/environment/production")
         .send({
           conversations: [],
-          processNlu: "false"
+          processNlu: "fallse"
         })
-        .expect(httpStatus.BAD_REQUEST)
+        .expect(httpStatus.UNPROCESSABLE_ENTITY)
         .then(res => {
           expect(res.body).to.deep.equal({
-            error: "processNlu should be an boolean"
+            errors: [
+                  {
+                    location: 'body',
+                    msg: 'processNlu should be an boolean',
+                    param: 'processNlu',
+                    value: 'fallse',
+                  }
+                ]
           });
           done();
         })

--- a/server/imports/imports.test.js
+++ b/server/imports/imports.test.js
@@ -1,0 +1,89 @@
+const request = require('supertest-as-promised');
+const httpStatus = require('http-status');
+const chai = require('chai');
+const expect = chai.expect;
+const app = require('../../app');
+chai.config.includeStack = true;
+const { Projects, NLUModels, Conversations } = require('../../models/models');
+
+function dateParser(key, value) {
+  if (key === 'updatedAt' || key === 'createdAt') {
+    return new Date(value * 1000);
+  }
+  return value;
+}
+before(function(done) {
+  const fs = require('fs');
+  const projectsFile = __dirname + '/test_data/projects.json';
+  const modelsFile = __dirname + '/test_data/nluModels.json';
+  const conversationFile = __dirname + '/test_data/conversations.json';
+  const projects = JSON.parse(fs.readFileSync(projectsFile, 'utf8'));
+  const models = JSON.parse(fs.readFileSync(modelsFile, 'utf8'));
+  const conversation = JSON.parse(
+    fs.readFileSync(conversationFile, 'utf8'),
+    dateParser
+  );
+  Projects.insertMany(projects)
+    .then(() => NLUModels.insertMany(models))
+    .then(() => Conversations.insertMany(conversation))
+    .then(() => {
+      done();
+    });
+});
+
+describe('## last import', () => {
+  describe('# GET /conversations/environment/{env}/latest-imported-event', () => {
+    it('Should retrieve last import in production', done => {
+      request(app)
+        .get('/conversations/environment/production/latest-imported-event')
+        .expect(httpStatus.OK)
+        .then(res => {
+          expect(res.body).to.deep.equal({
+            timestamp: 1550000000
+          });
+          done();
+        })
+        .catch(done);
+    });
+
+    it('Should give 0 as no import yet in staging', done => {
+      request(app)
+        .get('/conversations/environment/staging/latest-imported-event')
+        .expect(httpStatus.OK)
+        .then(res => {
+          expect(res.body).to.deep.equal({
+            timestamp: 0
+          });
+          done();
+        })
+        .catch(done);
+    });
+
+    it('Should retrieve last import in developement', done => {
+      request(app)
+        .get('/conversations/environment/developement/latest-imported-event')
+        .expect(httpStatus.OK)
+        .then(res => {
+          expect(res.body).to.deep.equal({
+            timestamp: 1450000000
+          });
+          done();
+        })
+        .catch(done);
+    });
+
+    it('Should return 400 when envirnonement does not exist', done => {
+      request(app)
+        .get('/conversations/environment/prodduction/latest-imported-event')
+        .expect(httpStatus.BAD_REQUEST)
+        .then(res => {
+          expect(res.body).to.deep.equal({
+            error:
+              'environement should be one of: production, staging, developement'
+          });
+          done();
+        })
+        .catch(done);
+    });
+  });
+});

--- a/server/imports/imports.test.js
+++ b/server/imports/imports.test.js
@@ -1,35 +1,35 @@
-const request = require('supertest-as-promised');
-const httpStatus = require('http-status');
-const chai = require('chai');
+const request = require("supertest-as-promised");
+const httpStatus = require("http-status");
+const chai = require("chai");
 const expect = chai.expect;
-const app = require('../../app');
+const app = require("../../app");
 chai.config.includeStack = true;
-const fs = require('fs');
+const fs = require("fs");
 const {
   Projects,
   NLUModels,
   Conversations,
   Activity
-} = require('../../models/models');
+} = require("../../models/models");
 
 const conversationsToImport = JSON.parse(
-  fs.readFileSync(__dirname + '/test_data/conversationsToImport.json', 'utf8')
+  fs.readFileSync(__dirname + "/test_data/conversationsToImport.json", "utf8")
 );
 
 function dateParser(key, value) {
-  if (key === 'updatedAt' || key === 'createdAt') {
+  if (key === "updatedAt" || key === "createdAt") {
     return new Date(value * 1000);
   }
   return value;
 }
 before(function(done) {
-  const projectsFile = __dirname + '/test_data/projects.json';
-  const modelsFile = __dirname + '/test_data/nluModels.json';
-  const conversationFile = __dirname + '/test_data/conversations.json';
-  const projects = JSON.parse(fs.readFileSync(projectsFile, 'utf8'));
-  const models = JSON.parse(fs.readFileSync(modelsFile, 'utf8'));
+  const projectsFile = __dirname + "/test_data/projects.json";
+  const modelsFile = __dirname + "/test_data/nluModels.json";
+  const conversationFile = __dirname + "/test_data/conversations.json";
+  const projects = JSON.parse(fs.readFileSync(projectsFile, "utf8"));
+  const models = JSON.parse(fs.readFileSync(modelsFile, "utf8"));
   const conversation = JSON.parse(
-    fs.readFileSync(conversationFile, 'utf8'),
+    fs.readFileSync(conversationFile, "utf8"),
     dateParser
   );
 
@@ -41,11 +41,11 @@ before(function(done) {
     });
 });
 
-describe('## last import', () => {
-  describe('# GET /conversations/{projectId}/environment/{env}/latest-imported-event', () => {
-    it('Should retrieve last import in production', done => {
+describe("## last import", () => {
+  describe("# GET /conversations/{projectId}/environment/{env}/latest-imported-event", () => {
+    it("Should retrieve last import in production", done => {
       request(app)
-        .get('/conversations/pro1/environment/production/latest-imported-event')
+        .get("/conversations/pro1/environment/production/latest-imported-event")
         .expect(httpStatus.OK)
         .then(res => {
           expect(res.body).to.deep.equal({
@@ -56,9 +56,9 @@ describe('## last import', () => {
         .catch(done);
     });
 
-    it('Should give 0 as no import yet in staging', done => {
+    it("Should give 0 as no import yet in staging", done => {
       request(app)
-        .get('/conversations/pro1/environment/staging/latest-imported-event')
+        .get("/conversations/pro1/environment/staging/latest-imported-event")
         .expect(httpStatus.OK)
         .then(res => {
           expect(res.body).to.deep.equal({
@@ -69,9 +69,11 @@ describe('## last import', () => {
         .catch(done);
     });
 
-    it('Should retrieve last import in developement', done => {
+    it("Should retrieve last import in development", done => {
       request(app)
-        .get('/conversations/pro1/environment/developement/latest-imported-event')
+        .get(
+          "/conversations/pro1/environment/development/latest-imported-event"
+        )
         .expect(httpStatus.OK)
         .then(res => {
           expect(res.body).to.deep.equal({
@@ -82,14 +84,16 @@ describe('## last import', () => {
         .catch(done);
     });
 
-    it('Should return 400 when envirnonement does not exist', done => {
+    it("Should return 400 when envirnonement does not exist", done => {
       request(app)
-        .get('/conversations/pro1/environment/prodduction/latest-imported-event')
+        .get(
+          "/conversations/pro1/environment/prodduction/latest-imported-event"
+        )
         .expect(httpStatus.BAD_REQUEST)
         .then(res => {
           expect(res.body).to.deep.equal({
             error:
-              'environement should be one of: production, staging, developement'
+              "environement should be one of: production, staging, development"
           });
           done();
         })
@@ -98,59 +102,59 @@ describe('## last import', () => {
   });
 });
 
-describe('## import format checking', () => {
-  describe('# POST /conversations/{projectId}/environment/{env}', () => {
-    it('should fail with invalid body', done => {
+describe("## import format checking", () => {
+  describe("# POST /conversations/{projectId}/environment/{env}", () => {
+    it("should fail with invalid body", done => {
       request(app)
-        .post('/conversations/pro1/environment/production')
+        .post("/conversations/pro1/environment/production")
         .send({
-          dummy: [{ name: 'test', confidence: 0.99 }],
-          text: 'blabla'
+          dummy: [{ name: "test", confidence: 0.99 }],
+          text: "blabla"
         })
         .expect(httpStatus.BAD_REQUEST)
         .then(res => {
           expect(res.body).to.deep.equal({
-            error: 'the body is missing conversations or processNlu, or both'
+            error: "the body is missing conversations or processNlu, or both"
           });
           done();
         })
         .catch(done);
     });
-    it('should fail with invalid conversations type', done => {
+    it("should fail with invalid conversations type", done => {
       request(app)
-        .post('/conversations/pro1/environment/production')
+        .post("/conversations/pro1/environment/production")
         .send({
-          conversations: 'bad',
+          conversations: "bad",
           processNlu: false
         })
         .expect(httpStatus.BAD_REQUEST)
         .then(res => {
           expect(res.body).to.deep.equal({
-            error: 'conversations should be an array'
+            error: "conversations should be an array"
           });
           done();
         })
         .catch(done);
     });
-    it('should fail with invalid processNlu type', done => {
+    it("should fail with invalid processNlu type", done => {
       request(app)
-        .post('/conversations/pro1/environment/production')
+        .post("/conversations/pro1/environment/production")
         .send({
           conversations: [],
-          processNlu: 'false'
+          processNlu: "false"
         })
         .expect(httpStatus.BAD_REQUEST)
         .then(res => {
           expect(res.body).to.deep.equal({
-            error: 'processNlu should be an boolean'
+            error: "processNlu should be an boolean"
           });
           done();
         })
         .catch(done);
     });
-    it('should import a new conversation and update and oldOne', done => {
+    it("should import a new conversation and update and oldOne", done => {
       request(app)
-        .post('/conversations/pro1/environment/production')
+        .post("/conversations/pro1/environment/production")
         .send({
           conversations: conversationsToImport.slice(0, 2),
           processNlu: true
@@ -158,24 +162,24 @@ describe('## import format checking', () => {
         .expect(httpStatus.OK)
         .then(async res => {
           expect(res.body).to.deep.equal({
-            message: 'successfuly imported all conversations'
+            message: "successfuly imported all conversations"
           });
-          Conversations.find({ _id: 'new' })
+          Conversations.find({ _id: "new" })
             .lean()
             .exec()
             .then(newData => {
               expect(newData).to.have.length(1);
-              expect(newData[0].projectId).to.equal('pro1');
-              Conversations.find({ _id: 'update' })
+              expect(newData[0].projectId).to.equal("pro1");
+              Conversations.find({ _id: "update" })
                 .lean()
                 .exec()
                 .then(updateData => {
                   expect(updateData).to.have.length(1);
-                  expect(updateData[0].projectId).to.equal('pro1');
+                  expect(updateData[0].projectId).to.equal("pro1");
                   expect(updateData[0].updatedAt).to.not.equal(
                     new Date(1550000000)
                   );
-                  Activity.find({ text: 'newevent' })
+                  Activity.find({ text: "newevent" })
                     .lean()
                     .exec()
                     .then(activityData => {
@@ -188,9 +192,9 @@ describe('## import format checking', () => {
         });
     });
 
-    it('should not import a conversation with a non undefined id', done => {
+    it("should not import a conversation with a non undefined id", done => {
       request(app)
-        .post('/conversations/pro1/environment/production')
+        .post("/conversations/pro1/environment/production")
         .send({
           conversations: conversationsToImport.slice(2, 3),
           processNlu: true
@@ -199,10 +203,10 @@ describe('## import format checking', () => {
         .then(async res => {
           expect(res.body).to.deep.equal({
             messageConversation:
-              'some conversation were not added, the field _id is missing',
+              "some conversation were not added, the field _id is missing",
             notValids: [conversationsToImport[2]]
           });
-          Conversations.find({ _id: 'projectnotexist' })
+          Conversations.find({ _id: "projectnotexist" })
             .lean()
             .exec()
             .then(newData => {
@@ -212,9 +216,9 @@ describe('## import format checking', () => {
         })
         .catch(done);
     });
-    it('should not import a parse data with unsupported language (no corresponding model)', done => {
+    it("should not import a parse data with unsupported language (no corresponding model)", done => {
       request(app)
-        .post('/conversations/pro1/environment/production')
+        .post("/conversations/pro1/environment/production")
         .send({
           conversations: conversationsToImport.slice(3),
           processNlu: true
@@ -223,12 +227,12 @@ describe('## import format checking', () => {
         .then(async res => {
           expect(res.body).to.deep.equal({
             messageParseData:
-              'Some parseData have not been added to activity, the corresponding models could not be found',
+              "Some parseData have not been added to activity, the corresponding models could not be found",
             invalidParseDatas: [
               [conversationsToImport[3].tracker.events[0].parse_data]
             ]
           });
-          Conversations.find({ _id: 'projectnotexist' })
+          Conversations.find({ _id: "projectnotexist" })
             .lean()
             .exec()
             .then(newData => {

--- a/server/imports/test_data/conversations.json
+++ b/server/imports/test_data/conversations.json
@@ -215,7 +215,7 @@
       "latest_action_name": "action_listen"
     },
     "status": "read",
-    "projectId": "bf",
+    "projectId": "pro1",
     "createdAt": 1400000000,
     "updatedAt": 1500000000,
     "env": "production"
@@ -436,7 +436,7 @@
       "latest_action_name": "action_listen"
     },
     "status": "read",
-    "projectId": "bf",
+    "projectId": "pro1",
     "createdAt": 1400000000,
     "updatedAt": 1550000000,
     "env": "production"
@@ -657,7 +657,7 @@
       "latest_action_name": "action_listen"
     },
     "status": "read",
-    "projectId": "bf",
+    "projectId": "pro1",
     "createdAt": 1400000000,
     "updatedAt": 1450000000,
     "env": "developement"
@@ -881,7 +881,7 @@
       "latest_action_name": "action_listen"
     },
     "status": "read",
-    "projectId": "bf",
+    "projectId": "pro1",
     "createdAt": 1400000000,
     "updatedAt": 1460000000
   }

--- a/server/imports/test_data/conversations.json
+++ b/server/imports/test_data/conversations.json
@@ -660,7 +660,7 @@
     "projectId": "pro1",
     "createdAt": 1400000000,
     "updatedAt": 1450000000,
-    "env": "developement"
+    "env": "development"
   },
   {
     "_id": "stagenoupdate",

--- a/server/imports/test_data/conversations.json
+++ b/server/imports/test_data/conversations.json
@@ -1,0 +1,888 @@
+[
+  {
+    "_id": "noupdate",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "bf",
+    "createdAt": 1400000000,
+    "updatedAt": 1500000000,
+    "env": "production"
+  },
+  {
+    "_id": "update",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "bf",
+    "createdAt": 1400000000,
+    "updatedAt": 1550000000,
+    "env": "production"
+  },
+  {
+    "_id": "devnoupdate",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "bf",
+    "createdAt": 1400000000,
+    "updatedAt": 1450000000,
+    "env": "developement"
+  },
+  {
+    "_id": "stagenoupdate",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": {
+          "name": "chitchat.bye",
+          "confidence": 0.9569626450538635
+        },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "bf",
+    "createdAt": 1400000000,
+    "updatedAt": 1460000000
+  }
+]

--- a/server/imports/test_data/conversationsToImport.json
+++ b/server/imports/test_data/conversationsToImport.json
@@ -215,9 +215,9 @@
       "latest_action_name": "action_listen"
     },
     "status": "read",
-    "projectId": "bf",
-    "createdAt": "2019-10-08T18:52:46.343Z",
-    "updatedAt": "2019-10-08T22:08:03.408Z",
+    "projectId": "pro1",
+    "createdAt": 1500000000,
+    "updatedAt": 1600000000,
     "env": "production"
   },
   {
@@ -457,9 +457,499 @@
       "latest_action_name": "action_listen"
     },
     "status": "read",
-    "projectId": "bf",
-    "createdAt": "2019-10-08T18:52:46.343Z",
-    "updatedAt": "2019-10-08T21:30:03.408Z",
+    "projectId": "pro1",
+    "createdAt": 1400000000,
+    "updatedAt": 1600000000,
+    "env": "production"
+  },
+  {
+    "_id": "projectnotexist",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": {
+          "name": "chitchat.bye",
+          "confidence": 0.9569626450538635
+        },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1670560776.8422823,
+          "text": "newevent",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "newevent"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "pro5",
+    "createdAt": 1400000000,
+    "updatedAt": 1600000000,
+    "env": "production"
+  },
+  {
+    "_id": "badparsedata",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": {
+          "name": "chitchat.bye",
+          "confidence": 0.9569626450538635
+        },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1770560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "gr",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1670560776.8422823,
+          "text": "newevent",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "newevent"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "pro1",
+    "createdAt": 1400000000,
+    "updatedAt": 1600000000,
     "env": "production"
   }
 ]

--- a/server/imports/test_data/conversationsToImport.json
+++ b/server/imports/test_data/conversationsToImport.json
@@ -1,0 +1,465 @@
+[
+  {
+    "_id": "new",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "bf",
+    "createdAt": "2019-10-08T18:52:46.343Z",
+    "updatedAt": "2019-10-08T22:08:03.408Z",
+    "env": "production"
+  },
+  {
+    "_id": "update",
+    "tracker": {
+      "sender_id": "b56825d548444e7b948a6801f94303ad",
+      "slots": { "disambiguation_message": null },
+      "latest_message": {
+        "intent": { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+        "entities": [],
+        "language": "en",
+        "intent_ranking": [
+          { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+          { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+        ],
+        "text": "bye"
+      },
+      "latest_event_time": 1570560776.8689356,
+      "followup_action": null,
+      "paused": false,
+      "events": [
+        {
+          "event": "action",
+          "timestamp": 1570560766.2965896,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": null
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560766.3634415,
+          "text": "",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "text": ""
+          },
+          "input_channel": "webchat",
+          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4099376,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560766.4099565,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560766.4099722 },
+        {
+          "event": "action",
+          "timestamp": 1570560766.4161348,
+          "name": "action_listen",
+          "policy": null,
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560770.552943,
+          "text": "Hello",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.greet",
+              "confidence": 0.93438720703125
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.greet", "confidence": 0.93438720703125 },
+              { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
+            ],
+            "text": "Hello"
+          },
+          "input_channel": "webchat",
+          "message_id": "30cfba7c62d546548414b2fcaf804147",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5711837,
+          "name": "utter_hi",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560770.571211,
+          "text": "Hello",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560770.5772521,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560772.6873093,
+          "text": "Nye",
+          "parse_data": {
+            "intent": { "name": null, "confidence": 0 },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [],
+            "text": "Nye"
+          },
+          "input_channel": "webchat",
+          "message_id": "ab31298483cd44008599c5d0889e9365",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7044666,
+          "name": "action_default_fallback",
+          "policy": "policy_0_FallbackPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560772.7044919,
+          "text": "utter_default",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        { "event": "rewind", "timestamp": 1570560772.7045 },
+        {
+          "event": "action",
+          "timestamp": 1570560772.7094045,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1570560776.8422823,
+          "text": "bye",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "bye"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8618143,
+          "name": "utter_bye",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "bot",
+          "timestamp": 1570560776.861832,
+          "text": "utter_bye",
+          "data": {
+            "elements": null,
+            "quick_replies": null,
+            "buttons": null,
+            "attachment": null,
+            "image": null,
+            "custom": null
+          },
+          "metadata": {}
+        },
+        {
+          "event": "action",
+          "timestamp": 1570560776.8689356,
+          "name": "action_listen",
+          "policy": "policy_1_AugmentedMemoizationPolicy",
+          "confidence": 1
+        },
+        {
+          "event": "user",
+          "timestamp": 1670560776.8422823,
+          "text": "newevent",
+          "parse_data": {
+            "intent": {
+              "name": "chitchat.bye",
+              "confidence": 0.9569626450538635
+            },
+            "entities": [],
+            "language": "en",
+            "intent_ranking": [
+              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
+              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
+            ],
+            "text": "newevent"
+          },
+          "input_channel": "webchat",
+          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
+          "metadata": null
+        }
+      ],
+      "latest_input_channel": "webchat",
+      "active_form": {},
+      "latest_action_name": "action_listen"
+    },
+    "status": "read",
+    "projectId": "bf",
+    "createdAt": "2019-10-08T18:52:46.343Z",
+    "updatedAt": "2019-10-08T21:30:03.408Z",
+    "env": "production"
+  }
+]

--- a/server/imports/test_data/conversationsToImport.json
+++ b/server/imports/test_data/conversationsToImport.json
@@ -463,7 +463,6 @@
     "env": "production"
   },
   {
-    "_id": "projectnotexist",
     "tracker": {
       "sender_id": "b56825d548444e7b948a6801f94303ad",
       "slots": { "disambiguation_message": null },
@@ -725,59 +724,10 @@
         ],
         "text": "bye"
       },
-      "latest_event_time": 1570560776.8689356,
+      "latest_event_time": 1770560770.552943,
       "followup_action": null,
       "paused": false,
       "events": [
-        {
-          "event": "action",
-          "timestamp": 1570560766.2965896,
-          "name": "action_listen",
-          "policy": null,
-          "confidence": null
-        },
-        {
-          "event": "user",
-          "timestamp": 1570560766.3634415,
-          "text": "",
-          "parse_data": {
-            "intent": { "name": null, "confidence": 0 },
-            "entities": [],
-            "text": ""
-          },
-          "input_channel": "webchat",
-          "message_id": "a9f2eabbfde34bbabfa430b5e2bcbbad",
-          "metadata": null
-        },
-        {
-          "event": "action",
-          "timestamp": 1570560766.4099376,
-          "name": "action_default_fallback",
-          "policy": "policy_0_FallbackPolicy",
-          "confidence": 1
-        },
-        {
-          "event": "bot",
-          "timestamp": 1570560766.4099565,
-          "text": "utter_default",
-          "data": {
-            "elements": null,
-            "quick_replies": null,
-            "buttons": null,
-            "attachment": null,
-            "image": null,
-            "custom": null
-          },
-          "metadata": {}
-        },
-        { "event": "rewind", "timestamp": 1570560766.4099722 },
-        {
-          "event": "action",
-          "timestamp": 1570560766.4161348,
-          "name": "action_listen",
-          "policy": null,
-          "confidence": 1
-        },
         {
           "event": "user",
           "timestamp": 1770560770.552943,
@@ -794,152 +744,7 @@
               { "name": "chitchat.bye", "confidence": 0.06561281532049179 }
             ],
             "text": "Hello"
-          },
-          "input_channel": "webchat",
-          "message_id": "30cfba7c62d546548414b2fcaf804147",
-          "metadata": null
-        },
-        {
-          "event": "action",
-          "timestamp": 1570560770.5711837,
-          "name": "utter_hi",
-          "policy": "policy_1_AugmentedMemoizationPolicy",
-          "confidence": 1
-        },
-        {
-          "event": "bot",
-          "timestamp": 1570560770.571211,
-          "text": "Hello",
-          "data": {
-            "elements": null,
-            "quick_replies": null,
-            "buttons": null,
-            "attachment": null,
-            "image": null,
-            "custom": null
-          },
-          "metadata": {}
-        },
-        {
-          "event": "action",
-          "timestamp": 1570560770.5772521,
-          "name": "action_listen",
-          "policy": "policy_1_AugmentedMemoizationPolicy",
-          "confidence": 1
-        },
-        {
-          "event": "user",
-          "timestamp": 1570560772.6873093,
-          "text": "Nye",
-          "parse_data": {
-            "intent": { "name": null, "confidence": 0 },
-            "entities": [],
-            "language": "en",
-            "intent_ranking": [],
-            "text": "Nye"
-          },
-          "input_channel": "webchat",
-          "message_id": "ab31298483cd44008599c5d0889e9365",
-          "metadata": null
-        },
-        {
-          "event": "action",
-          "timestamp": 1570560772.7044666,
-          "name": "action_default_fallback",
-          "policy": "policy_0_FallbackPolicy",
-          "confidence": 1
-        },
-        {
-          "event": "bot",
-          "timestamp": 1570560772.7044919,
-          "text": "utter_default",
-          "data": {
-            "elements": null,
-            "quick_replies": null,
-            "buttons": null,
-            "attachment": null,
-            "image": null,
-            "custom": null
-          },
-          "metadata": {}
-        },
-        { "event": "rewind", "timestamp": 1570560772.7045 },
-        {
-          "event": "action",
-          "timestamp": 1570560772.7094045,
-          "name": "action_listen",
-          "policy": "policy_1_AugmentedMemoizationPolicy",
-          "confidence": 1
-        },
-        {
-          "event": "user",
-          "timestamp": 1570560776.8422823,
-          "text": "bye",
-          "parse_data": {
-            "intent": {
-              "name": "chitchat.bye",
-              "confidence": 0.9569626450538635
-            },
-            "entities": [],
-            "language": "en",
-            "intent_ranking": [
-              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
-              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
-            ],
-            "text": "bye"
-          },
-          "input_channel": "webchat",
-          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
-          "metadata": null
-        },
-        {
-          "event": "action",
-          "timestamp": 1570560776.8618143,
-          "name": "utter_bye",
-          "policy": "policy_1_AugmentedMemoizationPolicy",
-          "confidence": 1
-        },
-        {
-          "event": "bot",
-          "timestamp": 1570560776.861832,
-          "text": "utter_bye",
-          "data": {
-            "elements": null,
-            "quick_replies": null,
-            "buttons": null,
-            "attachment": null,
-            "image": null,
-            "custom": null
-          },
-          "metadata": {}
-        },
-        {
-          "event": "action",
-          "timestamp": 1570560776.8689356,
-          "name": "action_listen",
-          "policy": "policy_1_AugmentedMemoizationPolicy",
-          "confidence": 1
-        },
-        {
-          "event": "user",
-          "timestamp": 1670560776.8422823,
-          "text": "newevent",
-          "parse_data": {
-            "intent": {
-              "name": "chitchat.bye",
-              "confidence": 0.9569626450538635
-            },
-            "entities": [],
-            "language": "en",
-            "intent_ranking": [
-              { "name": "chitchat.bye", "confidence": 0.9569626450538635 },
-              { "name": "chitchat.greet", "confidence": 0.04303739219903946 }
-            ],
-            "text": "newevent"
-          },
-          "input_channel": "webchat",
-          "message_id": "affc078bb70746ec95af11e0b0c3d9e5",
-          "metadata": null
+          }
         }
       ],
       "latest_input_channel": "webchat",

--- a/server/imports/test_data/nluModels.json
+++ b/server/imports/test_data/nluModels.json
@@ -1,0 +1,18 @@
+[
+  {
+    "_id": "nlu1",
+    "language": "en"
+  },
+  {
+    "_id": "nlu2",
+    "language": "fr"
+  },
+  {
+    "_id": "nlu3",
+    "language": "fr"
+  },
+  {
+    "_id": "nlu4",
+    "language": "en"
+  }
+]

--- a/server/imports/test_data/projects.json
+++ b/server/imports/test_data/projects.json
@@ -1,0 +1,10 @@
+[
+  {
+    "_id": "pro1",
+    "nlu_models": ["nlu1", "nlu2"]
+  },
+  {
+    "_id": "pro2",
+    "nlu_models": ["nlu3", "nlu4"]
+  }
+]


### PR DESCRIPTION
add a route to import new conversations
add a route to retreive last import timestamp

[x] Tests of new routes
[x] documentation of new routes

Should retrieve last import in production
Should give 0 as no import yet in staging
Should retrieve last import in developement
Should return 400 when envirnonement does not exist

should fail with invalid conversations type
should fail with invalid processNlu type
should import a new conversation and update and oldOne
should not import a conversation with a non existing project id
should not import a wrong parse data with a non existing project id